### PR TITLE
feat: enable tx pool sync by force

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -150,8 +150,6 @@ var (
 		utils.GpoIgnoreGasPriceFlag,
 		utils.MinerNotifyFullFlag,
 		utils.IgnoreLegacyReceiptsFlag,
-		utils.RollupSequencerHTTPFlag,
-		utils.RollupDisableTxPoolGossipFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -910,19 +910,6 @@ var (
 		Category: flags.GasPriceCategory,
 	}
 
-	// Rollup Flags
-	RollupSequencerHTTPFlag = &cli.StringFlag{
-		Name:     "rollup.sequencerhttp",
-		Usage:    "HTTP endpoint for the sequencer mempool",
-		Category: flags.RollupCategory,
-	}
-
-	RollupDisableTxPoolGossipFlag = &cli.BoolFlag{
-		Name:     "rollup.disabletxpoolgossip",
-		Usage:    "Disable transaction pool gossip.",
-		Category: flags.RollupCategory,
-	}
-
 	// Metrics flags
 	MetricsEnabledFlag = &cli.BoolFlag{
 		Name:     "metrics",
@@ -1918,11 +1905,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 		cfg.SyncTarget = &block
 	}
-	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
-	if ctx.IsSet(RollupSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
-		cfg.RollupSequencerHTTP = ctx.String(RollupSequencerHTTPFlag.Name)
-	}
-	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	// Override any default configs for hard coded networks.
 	switch {
 	case ctx.Bool(MainnetFlag.Name):

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
@@ -258,15 +257,6 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, tx *types.Transaction) error {
-	if b.eth.seqRPCService != nil {
-		data, err := tx.MarshalBinary()
-		if err != nil {
-			return err
-		}
-		if err := b.eth.seqRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data)); err != nil {
-			return err
-		}
-	}
 	return b.eth.txPool.AddLocal(tx)
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -217,10 +217,6 @@ type Config struct {
 	// development purposes.
 	SyncTarget *types.Block
 
-	RollupSequencerHTTP string
-
-	RollupDisableTxPoolGossip bool
-
 	// [Scroll: START]
 	// Trace option
 	MPTWitness int

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -87,7 +87,6 @@ type handlerConfig struct {
 	EventMux       *event.TypeMux            // Legacy event mux, deprecate for `feed`
 	Checkpoint     *params.TrustedCheckpoint // Hard coded checkpoint for sync challenges
 	RequiredBlocks map[uint64]common.Hash    // Hard coded map of required block hashes for sync challenges
-	NoTxGossip     bool                      // Disable P2P transaction gossip
 }
 
 type handler struct {
@@ -104,8 +103,6 @@ type handler struct {
 	txpool   txPool
 	chain    *core.BlockChain
 	maxPeers int
-
-	noTxGossip bool
 
 	downloader   *downloader.Downloader
 	blockFetcher *fetcher.BlockFetcher
@@ -140,7 +137,6 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		eventMux:       config.EventMux,
 		database:       config.Database,
 		txpool:         config.TxPool,
-		noTxGossip:     config.NoTxGossip,
 		chain:          config.Chain,
 		peers:          newPeerSet(),
 		merger:         config.Merger,

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -35,17 +35,7 @@ type ethHandler handler
 
 func (h *ethHandler) Chain() *core.BlockChain { return h.chain }
 
-// NilPool satisfies the TxPool interface but does not return any tx in the
-// pool. It is used to disable transaction gossip.
-type NilPool struct{}
-
-// NilPool Get always returns nil
-func (n NilPool) Get(hash common.Hash) *types.Transaction { return nil }
-
 func (h *ethHandler) TxPool() eth.TxPool {
-	if h.noTxGossip {
-		return &NilPool{}
-	}
 	return h.txpool
 }
 
@@ -65,9 +55,6 @@ func (h *ethHandler) PeerInfo(id enode.ID) interface{} {
 // AcceptTxs retrieves whether transaction processing is enabled on the node
 // or if inbound transactions should simply be dropped.
 func (h *ethHandler) AcceptTxs() bool {
-	if h.noTxGossip {
-		return false
-	}
 	return atomic.LoadUint32(&h.acceptTxs) == 1
 }
 

--- a/les/client.go
+++ b/les/client.go
@@ -18,7 +18,6 @@
 package les
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -66,8 +65,6 @@ type LightEthereum struct {
 	serverPoolIterator enode.Iterator
 	pruner             *pruner
 	merger             *consensus.Merger
-
-	seqRPCService *rpc.Client
 
 	bloomRequests chan chan *bloombits.Retrieval // Channel receiving bloom data retrieval requests
 	bloomIndexer  *core.ChainIndexer             // Bloom indexer operating during block imports
@@ -196,16 +193,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	if leth.handler.ulc != nil {
 		log.Warn("Ultra light client is enabled", "trustedNodes", len(leth.handler.ulc.keys), "minTrustedFraction", leth.handler.ulc.fraction)
 		leth.blockchain.DisableCheckFreq()
-	}
-
-	if config.RollupSequencerHTTP != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		client, err := rpc.DialContext(ctx, config.RollupSequencerHTTP)
-		cancel()
-		if err != nil {
-			return nil, err
-		}
-		leth.seqRPCService = client
 	}
 
 	leth.netRPCService = ethapi.NewNetAPI(leth.p2pServer, leth.config.NetworkId)


### PR DESCRIPTION
This commit removes 2 flags.

- `RollupSequencerHttpFlag`: This transfers transaction to geth that is specified with this flag.
- `RollupDisableTxPoolGossipFlag`: This diables tx pool sync if this flag is on.